### PR TITLE
Fix for gRPC empty response for userServer.Dispach method

### DIFF
--- a/internal/userserver/server.go
+++ b/internal/userserver/server.go
@@ -44,7 +44,7 @@ func (s *userServer) Dispatch(ctx context.Context, cmd *pb.Command) (*pb.Respons
 		return nil, err
 	}
 
-	return nil, nil
+	return new(pb.Response), nil
 }
 
 // New returns new user domain server object


### PR DESCRIPTION
[#golangsyd]